### PR TITLE
Backwards compatibility for cssdyn

### DIFF
--- a/config.json
+++ b/config.json
@@ -36,6 +36,7 @@
   "template_dyn_py_ext": ".dynpy",
   "remove_parent_inherited": true,
   "use_long_import_names": true,
+  "dyn_ns_import_check": true,
   "db_mod_info": "mod_info.sqlite",
   "inc_lic": "resources/inc_lic.txt",
   "component_types": ["const", "enum", "exception", "interface", "singleton", "service", "struct", "typedef"],

--- a/config.py
+++ b/config.py
@@ -135,6 +135,18 @@ class AppConfig:
     """
     inc_lic: str
     """Path to License Include File"""
+    dyn_ns_import_check: bool
+    """
+    Determines if import checks are done for cssdyn namespace exports
+    
+    Some classes in the cssdyn namespace may not be availible on older version of LO
+    such as ``com.sun.star.util.XBinaryDataContainer`` which is a LO 7.2 interface.
+    If an attempt to import this class in older ver then the entire process will fail
+    Adding import check resolves this issue.
+    
+    Newer releases of this lin can probally turn this off and user can then use previous
+    version for backward compatibility.
+    """
 
 def read_config(config_file: str) -> AppConfig:
     """


### PR DESCRIPTION
Some classes can not be imported in older version of LO
simply because they do not exist.

By wrapping cssdyn import is try blocks lib can be used with
older version of LO (pre 7.2)